### PR TITLE
Support the width property

### DIFF
--- a/ImageSlider.js
+++ b/ImageSlider.js
@@ -64,12 +64,13 @@ export default class ImageSlider extends Component {
     }
 
     _move(index) {
+        const width = this.props.width || this.state.width;
         const isUpdating = index !== this._getPosition();
-        const x = this.state.width * index;
+        const x = width * index;
         if (majorVersion === 0 && minorVersion <= 19) {
             this._ref.scrollTo(0, x, true); // use old syntax
         } else {
-            this._ref.scrollTo({x: this.state.width * index, y: 0, animated: true});
+            this._ref.scrollTo({x: width * index, y: 0, animated: true});
         }
         this.setState({position: index});
         if (isUpdating && this.props.onPositionChanged) {
@@ -91,10 +92,8 @@ export default class ImageSlider extends Component {
     }
 
     componentWillMount() {
-        const width = this.state.width;
-
         let release = (e, gestureState) => {
-            const width = this.state.width;
+            const width = this.props.width || this.state.width;
             const relativeDistance = gestureState.dx / width;
             const vx = gestureState.vx;
             let change = 0;
@@ -119,8 +118,9 @@ export default class ImageSlider extends Component {
         });
 
         this._interval = setInterval(() => {
+            const width = this.props.width || this.state.width;
             const newWidth = Dimensions.get('window').width;
-            if (newWidth !== this.state.width) {
+            if (newWidth !== width) {
                 this.setState({width: newWidth});
             }
         }, 16);
@@ -131,7 +131,7 @@ export default class ImageSlider extends Component {
     }
 
     render() {
-        const width = this.state.width;
+        const width = this.props.width || this.state.width;
         const height = this.props.height || this.state.height;
         const position = this._getPosition();
         return (<View>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ If you want to change the height, simply pass a height to the component.
 
 ### Props
 
-* `height`: controls the height. By default the height is static, is this if you want the height to change
+* `width`: controls the width. By default the width is static. Specify this property to change the width
+* `height`: controls the height. By default the height is static. Specify this property to change the height
 * `onPositionChanged`: called when the current position is changed
 * `position`: used for controlled components
 * `onPress`: returns an object with image url and index of image pressed


### PR DESCRIPTION
Being able to specify the height wasn't enough to get my slider to render how I wanted. I also noticed that due to the width being static and the height being modified by specifying `this.props.height` the buttons at the bottom didn't move properly to the next image when clicking on them. This was also due to the `width` being calculated in the constructor.

I added support for specifying `this.props.width` and updated any use of `this.state.width` to take into account the possibility of `this.props.width` being set. I also updated the read me