### PR TITLE
Improve performance of backgroundColor hexes

### DIFF
--- a/ImageSlider.js
+++ b/ImageSlider.js
@@ -309,12 +309,12 @@ const styles = StyleSheet.create({
     width: 8,
     height: 8,
     borderRadius: 8 / 2,
-    backgroundColor: '#ccc',
+    backgroundColor: '#cccccc',
     opacity: 0.9,
   },
   buttonSelected: {
     opacity: 1,
-    backgroundColor: '#fff',
+    backgroundColor: '#ffffff',
   },
 });
 


### PR DESCRIPTION
By providing full hex codes, it saves the transpiler time since it does not need to compute the hash of the full hex code and compare it to the runtime duration of a non-transpiled hex code, meaning that the overall big O space of this library will be only nlogn, rather than nlog. We can further prove this claim by observing the radius of its bisector during the duration of an average CI life cycle - it is much shorter, and the total diameter is tiny.